### PR TITLE
On the fly scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ LOONE_WQ(workspace="/path/to/workspace")
 
 # predefined variables
 schedule: "LORS20082023"
-sim_type: 0  # 0:Scenario_Simulation 1:Optimization_Validation 2:Optimization
+sim_type: 0  # 0:Scenario_Simulation 1:Optimization_Validation 2:Optimization 3:Loone_Scenarios_App_Simulation
 start_year: 2008
 end_year: 2023
 start_date_entry: [2008, 1, 1]
@@ -223,6 +223,12 @@ v_burial_r: 0.0000003  # 1.0e-05 #(m/day)#0.00017333#(m/month)# 0.00208 (m/yr)
 v_burial_p: 0.0000003  # 1.0e-05 #(m/day)#0.00017333#(m/month)# 0.00208 (m/yr)
 
 nondominated_sol_var: "nondominated_Sol_var.csv"
+
+wca_stages_inputs: "WCA_Stages_Inputs.csv"
+lo_inflows_bk: "LO_Inflows_BK.csv"
+sto_stage: "Average_LO_Storage_3MLag.csv"
+wind_shear_stress: "WindShearStress.csv"
+nu: "nu.csv"
 ```
 
 ## Case Study:

--- a/loone/loone_q/LOONE_Q.py
+++ b/loone/loone_q/LOONE_Q.py
@@ -1690,23 +1690,24 @@ def _create_dectree_df(date_range_5: pd.DatetimeIndex, tc_lonino_df: pd.DataFram
     return dec_tree_df
 
 
-def _calculate_pulse_averages(data: object) -> dict:
+def _calculate_pulse_averages(data: object, config: dict) -> dict:
     """
     Calculate the pulse averages for S-80 and S-77.
 
     Args:
         data (object): The data object containing pulse information.
+        config (dict): The configuration dictionary.
 
     Returns:
         dict: A dictionary containing the pulse averages for S-80 and S-77.
     """
     pulse_averages = {
-        "s80avg_l1": data.Pulses["S-80_L1_LORS20082023"].mean(),
-        "s80avg_l2": data.Pulses["S-80_L2_LORS20082023"].mean(),
-        "s80avg_l3": data.Pulses["S-80_L3_LORS20082023"].mean(),
-        "s77avg_l1": data.Pulses["S-77_L1_LORS20082023"].mean(),
-        "s77avg_l2": data.Pulses["S-77_L2_LORS20082023"].mean(),
-        "s77avg_l3": data.Pulses["S-77_L3_LORS20082023"].mean(),
+        "s80avg_l1": data.Pulses[f"S-80_L1_{config['schedule']}"].mean(),
+        "s80avg_l2": data.Pulses[f"S-80_L2_{config['schedule']}"].mean(),
+        "s80avg_l3": data.Pulses[f"S-80_L3_{config['schedule']}"].mean(),
+        "s77avg_l1": data.Pulses[f"S-77_L1_{config['schedule']}"].mean(),
+        "s77avg_l2": data.Pulses[f"S-77_L2_{config['schedule']}"].mean(),
+        "s77avg_l3": data.Pulses[f"S-77_L3_{config['schedule']}"].mean(),
     }
     return pulse_averages
 
@@ -1805,7 +1806,7 @@ def LOONE_Q(workspace: str, p1: float, p2: float, s77_dv: float, s308_dv: float,
     outlet2_baseflow = data.S80_RegRelRates["Zone_D0"].iloc[0]
     _calculate_basin_runoff(basin_ro, data, outlet1_baseflow, outlet2_baseflow)
     lo_model["C43RO"] = data.C43RO_Daily["C43RO"]
-    pulse_averages = _calculate_pulse_averages(data)
+    pulse_averages = _calculate_pulse_averages(data, config)
     s80avg_l1 = pulse_averages["s80avg_l1"]
     s80avg_l2 = pulse_averages["s80avg_l2"]
     s80avg_l3 = pulse_averages["s80avg_l3"]

--- a/loone/loone_q/LOONE_Q.py
+++ b/loone/loone_q/LOONE_Q.py
@@ -4,6 +4,7 @@ import pandas as pd
 import numpy as np
 from datetime import datetime, timedelta
 from calendar import monthrange
+from typing import List
 from loone.utils import (
     load_config,
     replicate,
@@ -684,7 +685,7 @@ def _calculate_outlet2usrg_code(i: int, model_variables: object, lo_functions: o
             ]
         else:
             model_variables.Outlet2USRG[i + 2] = 0
-    else:
+    elif config["sim_type"] == 3:
         if model_variables.Lake_Stage[i + 1] >= 18:
             model_variables.Outlet2USRG[i + 2] = 7200
         else:
@@ -1052,7 +1053,7 @@ def _define_thc_class_normal_or_above(i: int, n_rows: int, model_variables: obje
 
 def _calculate_outlet1usreg(i: int, model_variables: object, lo_functions: object, data: object, config: dict,
                             tp_lake_s: float, s77_dv: float, date_range_6: pd.DatetimeIndex,
-                            lo_model: pd.DataFrame) -> None:
+                            lo_model: pd.DataFrame, sensitivity_analysis_params) -> None:
     """
     Calculate the Outlet1USREG for the given index.
 
@@ -1066,6 +1067,7 @@ def _calculate_outlet1usreg(i: int, model_variables: object, lo_functions: objec
         s77_dv (float): The s77_dv value.
         date_range_6 (pd.DatetimeIndex): The date range.
         lo_model (pd.DataFrame): The model DataFrame.
+        sensitivity_analysis_params (list): Holds a release rate for each month of the year.
 
     Returns:
         None
@@ -1097,36 +1099,35 @@ def _calculate_outlet1usreg(i: int, model_variables: object, lo_functions: objec
             ]
         else:
             model_variables.Outlet1USREG[i + 2] = 0
-    else:
+    elif config["sim_type"] == 3:
         if model_variables.Lake_Stage[i + 1] >= 18:
             model_variables.Outlet1USREG[i + 2] = 7200
         elif model_variables.Lake_Stage[i + 1] <= 8:
             model_variables.Outlet1USREG[i + 2] = 0
-        # TODO:  get the SA_Par variable used in the code below:
-        # elif lo_model.at[i + 2, 'date'].month == 1:
-        #     model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], SA_Par[0], SA_Par[1], SA_Par[2])
-        # elif lo_model.at[i + 2, 'date'].month == 2:
-        #     model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], SA_Par[3], SA_Par[4], SA_Par[5])
-        # elif lo_model.at[i + 2, 'date'].month == 3:
-        #     model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], SA_Par[6], SA_Par[7], SA_Par[8])
-        # elif lo_model.at[i + 2, 'date'].month == 4:
-        #     model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], SA_Par[9], SA_Par[10], SA_Par[11])
-        # elif lo_model.at[i + 2, 'date'].month == 5:
-        #     model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], SA_Par[12], SA_Par[13], SA_Par[14])
-        # elif lo_model.at[i + 2, 'date'].month == 6:
-        #     model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], SA_Par[15], SA_Par[16], SA_Par[17])
-        # elif lo_model.at[i + 2, 'date'].month == 7:
-        #     model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], SA_Par[18], SA_Par[19], SA_Par[20])
-        # elif lo_model.at[i + 2, 'date'].month == 8:
-        #     model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], SA_Par[21], SA_Par[22], SA_Par[23])
-        # elif lo_model.at[i + 2, 'date'].month == 9:
-        #     model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], SA_Par[24], SA_Par[25], SA_Par[26])
-        # elif lo_model.at[i + 2, 'date'].month == 10:
-        #     model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], SA_Par[27], SA_Par[28], SA_Par[29])
-        # elif lo_model.at[i + 2, 'date'].month == 11:
-        #     model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], SA_Par[30], SA_Par[31], SA_Par[32])
-        # elif lo_model.at[i + 2, 'date'].month == 12:
-        #     model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], SA_Par[33], SA_Par[34], SA_Par[35])
+        elif lo_model.at[i + 2, 'date'].month == 1:
+            model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], sensitivity_analysis_params[0])
+        elif lo_model.at[i + 2, 'date'].month == 2:
+            model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], sensitivity_analysis_params[1])
+        elif lo_model.at[i + 2, 'date'].month == 3:
+            model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], sensitivity_analysis_params[2])
+        elif lo_model.at[i + 2, 'date'].month == 4:
+            model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], sensitivity_analysis_params[3])
+        elif lo_model.at[i + 2, 'date'].month == 5:
+            model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], sensitivity_analysis_params[4])
+        elif lo_model.at[i + 2, 'date'].month == 6:
+            model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], sensitivity_analysis_params[5])
+        elif lo_model.at[i + 2, 'date'].month == 7:
+            model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], sensitivity_analysis_params[6])
+        elif lo_model.at[i + 2, 'date'].month == 8:
+            model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], sensitivity_analysis_params[7])
+        elif lo_model.at[i + 2, 'date'].month == 9:
+            model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], sensitivity_analysis_params[8])
+        elif lo_model.at[i + 2, 'date'].month == 10:
+            model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], sensitivity_analysis_params[9])
+        elif lo_model.at[i + 2, 'date'].month == 11:
+            model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], sensitivity_analysis_params[10])
+        elif lo_model.at[i + 2, 'date'].month == 12:
+            model_variables.Outlet1USREG[i + 2] = lo_functions.Outlet_Rel_Sim(model_variables.Release_Level[i + 2], sensitivity_analysis_params[11])
 
 
 def _calculate_outlet1ds(i: int, model_variables: object, lo_functions: object, data: object, config: dict) -> None:
@@ -1734,7 +1735,7 @@ def _initialize_model_variables_stage_levels_flags(model_variables: object, conf
     model_variables.DayFlags[2] = _determine_day_flags(startdate, lo_model, begdateCS)
 
 
-def LOONE_Q(workspace: str, p1: float, p2: float, s77_dv: float, s308_dv: float, tp_lake_s: float) -> None:
+def LOONE_Q(workspace: str, p1: float, p2: float, s77_dv: float, s308_dv: float, tp_lake_s: float, sensitivity_analysis_params: List[float] = []) -> None:
     """This function runs the LOONE Q module.
 
     Args:
@@ -1744,6 +1745,7 @@ def LOONE_Q(workspace: str, p1: float, p2: float, s77_dv: float, s308_dv: float,
         s77_dv (float): s77_dv value.
         s308_dv (float): s308_dv value.
         tp_lake_s (float): tp_lake_s value.
+        sensitivity_analysis_params (List[float], optional): Holds a release rate for each month of the year. Required when sim_type is 3. Defaults to [].
 
     Returns:
         None
@@ -1759,7 +1761,7 @@ def LOONE_Q(workspace: str, p1: float, p2: float, s77_dv: float, s308_dv: float,
     startdate, begdateCS, enddate = _define_start_and_end_dates(config)
 
     ###################################################################
-    if config["sim_type"] in [0, 1]:
+    if config["sim_type"] in [0, 1, 3]:
         df_wsms.WSMs(workspace)
 
     df_WSMs = pd.read_csv("df_WSMs.csv")
@@ -1881,7 +1883,7 @@ def LOONE_Q(workspace: str, p1: float, p2: float, s77_dv: float, s308_dv: float,
                                           targ_stg_df, data, choose_1)
         _calculate_outlet1usbsap(i, model_variables, lo_functions, config)
         _calculate_outlet1usews(i, model_variables, lo_functions, data, config)
-        _calculate_outlet1usreg(i, model_variables, lo_functions, data, config, tp_lake_s, s77_dv, date_range_6, lo_model)
+        _calculate_outlet1usreg(i, model_variables, lo_functions, data, config, tp_lake_s, s77_dv, date_range_6, lo_model, sensitivity_analysis_params)
         _calculate_outlet1ds(i, model_variables, lo_functions, data, config)
         _calculate_tot_reg_ew(i, model_variables)
         _calculate_choose_wca(i, model_variables, lo_functions, data, config)
@@ -1899,7 +1901,14 @@ def LOONE_Q(workspace: str, p1: float, p2: float, s77_dv: float, s308_dv: float,
     # this data.
     lo_model.to_csv("LOONE_Q_Outputs.csv")
 
-    return [lo_model]
+    # Add scenario data to output df
+    df_stage = pd.DataFrame(data = model_variables.Lake_Stage, columns = ['Outputs'])
+    df_caloosahatchee = pd.DataFrame(data = model_variables.Outlet1USREG, columns = ['Outputs'])
+    df_saint_lucie = pd.DataFrame(data = model_variables.Outlet2USRG, columns = ['Outputs'])
+    df_south = pd.DataFrame(data = model_variables.TotRegSo/1.9835, columns = ['Outputs'])
+    df_out = pd.concat([df_stage, df_caloosahatchee, df_saint_lucie, df_south])
+    
+    return [lo_model, df_out.T.loc['Outputs']]
 
 
 if __name__ == "__main__":

--- a/loone/utils/lo_functions.py
+++ b/loone/utils/lo_functions.py
@@ -673,15 +673,13 @@ def Outlet2DSRS(
     return S
 
 
-def Outlet_Rel_Sim(release_level, relase_rate_l, release_rate_m, release_rate_h):
+def Outlet_Rel_Sim(release_level, release_rate):
     """
     Simulate the outlet release based on the release level and rates.
 
     Args:
-        relese_level (int): The release level.
-        release_rate_l (float): The low release rate.
-        release_rate_m (float): The medium release rate.
-        release_rate_h (float): The high release rate.
+        release_level (int): The release level.
+        release_rate (float): The release rate chosen by the user.
 
     Returns:
         float: The simulated outlet release.
@@ -691,18 +689,8 @@ def Outlet_Rel_Sim(release_level, relase_rate_l, release_rate_m, release_rate_h)
         s = 0
     elif (release_level + 2) == 2:
         s = 0
-    elif (release_level + 2) == 3:
-        s = relase_rate_l
-    elif (release_level + 2) == 4:
-        s = relase_rate_l
-    elif (release_level + 2) == 5:
-        s = relase_rate_l
-    elif (release_level + 2) == 6:
-        s = release_rate_m
-    elif (release_level + 2) == 7:
-        s = release_rate_m
-    elif (release_level + 2) == 8:
-        s = release_rate_h
+    else:
+        s = release_rate
     return s
 
 

--- a/loone/utils/wca_stages_class.py
+++ b/loone/utils/wca_stages_class.py
@@ -32,7 +32,7 @@ def WCA_Stages_Cls(workspace: str, TC_LONINO_df: pd.DataFrame | None):
     date_rng_5 = pd.date_range(start=startdate, end=enddate, freq="D")
 
     # Read the WCA Stage data
-    WCA_Stages = pd.read_csv(os.path.join(workspace, "WCA_Stages_Inputs.csv"))
+    WCA_Stages = pd.read_csv(os.path.join(workspace, config["wca_stages_inputs"]))
     WCA_Stages.columns = WCA_Stages.columns.str.strip()
     # Read WCA3A_REG inputs
     # Note that I added a date column in the first column and I copied values of Feb28 to the Feb29!


### PR DESCRIPTION
- Updated LOONE_Q.py
  - LOONE_Q now takes an additional optional argument for when the config["sim_type"] is 3.
  - Uncommented the code for the Loone Planning app scenarios and made it run when config["sim_type"] is 3.
  - Added an additional Pandas.DataFrame to the list of returned outputs which is used by the Loone Planning app.
  
- Updated LOONE_NUT.py
  - Added an additional optional argument that is a dictionary of Pandas.DataFrames.
     When provided, these DataFrames are used instead of the DataFrames that are read in
     from the csv files specified by the config.

- Updated lo_functions.py
  - Updated Outlet_Rel_Sim() so it takes only one release_rate and no longer uses low, medium, and high release rates.

- Updated some util functions so they use the config to identify the files they read from instead of hard coding these names.

- Updated README.md
  - Added to a comment showing that a sim_type of 3 is for Loone_Scenarios_App_Simulation
  - Added examples for new entries in the config file. These new entries specify file names that LOONE will now
    now use to find its data.
