### PR TITLE
Add on-the-fly scenarios support to LOONE_WQ.py for the Loone Planning App

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ lo_inflows_bk: "LO_Inflows_BK.csv"
 sto_stage: "Average_LO_Storage_3MLag.csv"
 wind_shear_stress: "WindShearStress.csv"
 nu: "nu.csv"
+
+outflows_observed: "Flow_df_3MLag.csv"
 ```
 
 ## Case Study:


### PR DESCRIPTION
- Storage data's input file is now specified through the config
- LO_Inflows_BK's input file is now specified through the config when not forecasting
- Outflows observed's input file is now specified through the config
- Fixed a bug where nothing was returned when the config type wasn't 0 or 1
- Updated LOONE_WQ.py to account for a sim_type of 3
- Updated README.md to include new config entries