### PR TITLE
Add archived data download notebook

### DIFF
--- a/download-archived-data.ipynb
+++ b/download-archived-data.ipynb
@@ -1,0 +1,206 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c19500c2-973e-4d0f-ae8f-4ea045708dd8",
+   "metadata": {},
+   "source": [
+    "# Downloading LOONE Run Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef6b9ab3-3c4f-49cc-9d5b-1da65b8d2165",
+   "metadata": {},
+   "source": [
+    "This notebook shows a few different ways to download the files associated with the LOONE runs carried out by the [Loone Forecast App](https://close-habs.aquaveo.com/apps/loone-model/)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bee5ca5-794a-4d1e-9acf-6a26d84fbff9",
+   "metadata": {},
+   "source": [
+    "## Using Python"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "750c2307-ae73-4719-a2e3-4754e1126ca3",
+   "metadata": {},
+   "source": [
+    "#### 1. Install google-cloud-storage Python Package"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acf1ea87-f77a-4e11-94a5-f0dc50117ca9",
+   "metadata": {},
+   "source": [
+    "Python can be used to download the LOONE data by using the `google-cloud-storage` python package. First, we need to install `google-cloud-storage` using `pip`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8624f658-226d-4b70-8435-e3bf4dcfb789",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Install google-cloud-storage python package. Skip if already installed\n",
+    "%pip install google-cloud-storage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ec6196d-25f9-4cfd-be9c-c628de16d955",
+   "metadata": {},
+   "source": [
+    "> Running `%pip install google-cloud-storage` in the cell above installs the `google-cloud-storage` package into the current notebook kernel.\n",
+    ">\n",
+    "> If you want to install `google-cloud-storage` from a terminal instead, run `pip install google-cloud-storage` in the same Python environment used by this notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0627b941-bc92-4291-bb53-dd534ea6ff42",
+   "metadata": {},
+   "source": [
+    "#### 2. Import Packages and set Configuration Variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64883648-6eb4-4b6d-9645-b311dd96f971",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Imports\n",
+    "from datetime import datetime\n",
+    "import os\n",
+    "from google.cloud import storage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cd0b1f8-53ba-4f1a-92cb-03b9db818ee7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuration\n",
+    "date = datetime(2026, 3, 10)                                # The date of the run whose data you want\n",
+    "output_path = os.path.join(os.getcwd(), 'archived-data')    # The directory where you want the downloaded files to go"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63adbec2-7724-4546-afdf-e5c1a016351f",
+   "metadata": {},
+   "source": [
+    "#### 3. Helper Function"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4323bb01-5383-4a91-95ec-ad290c0fe666",
+   "metadata": {},
+   "source": [
+    "The following function can be used to download the archived data of the [Loone Forecast App](https://close-habs.aquaveo.com/apps/loone-model/):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a9d0cbc-573f-4502-8a18-6552ebd2ee1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def download_archived_data(date: datetime.datetime, output_path: str):\n",
+    "    \"\"\"Downloads the archived data for the specified date to the given output location.\n",
+    "\n",
+    "    Args:\n",
+    "       (datetime.datetime) date: The date of the run you want the data from.\n",
+    "       (str) output_path: The path to the directory where the downloaded files should go.\n",
+    "    \"\"\"\n",
+    "    # Get date as a string in the expected format\n",
+    "    date_string = date.strftime('%Y-%m-%d')\n",
+    "    \n",
+    "    # Get client and bucket for downloading the data\n",
+    "    bucket_name = 'loone-forecast-datastore'\n",
+    "    prefix = f'public/{date_string}'\n",
+    "    client = storage.Client.create_anonymous_client()\n",
+    "    bucket = client.bucket(bucket_name)\n",
+    "\n",
+    "    # Download all the files for the given date\n",
+    "    file_download_count = 0\n",
+    "\n",
+    "    try:\n",
+    "        for blob in client.list_blobs(bucket_name, prefix=prefix):\n",
+    "            # Get the location the file will be downloaded to\n",
+    "            blob_output_path = os.path.join(output_path, blob.name.removeprefix('public/'))\n",
+    "            blob_output_dir = os.path.dirname(blob_output_path)\n",
+    "    \n",
+    "            # Create the directories the files will be output to\n",
+    "            if not os.path.exists(blob_output_dir):\n",
+    "                os.makedirs(blob_output_dir, exist_ok=True)\n",
+    "            \n",
+    "            # Download the file\n",
+    "            blob.download_to_filename(blob_output_path)\n",
+    "    \n",
+    "            # Notify user of progress\n",
+    "            print(f'Downloaded {blob.name}')\n",
+    "    \n",
+    "            # Keep track of how many files we download\n",
+    "            file_download_count += 1\n",
+    "    except Exception as e:\n",
+    "        print(f'Failed to download {blob.name}')\n",
+    "    \n",
+    "    # Notify user the downloads are complete\n",
+    "    print(f'Downloads Complete! {file_download_count} file(s) downloaded')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "005ef4db-2c12-4ddb-af5e-18f54fde1f0c",
+   "metadata": {},
+   "source": [
+    "#### 4. Run the Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c681ce6-945c-447c-a29a-8d33b8e7c876",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "download_archived_data(date, output_path)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds a jupyter notebook that illustrates how to download the archived LOONE forecast run data from the [Loone Forecast App](https://close-habs.aquaveo.com/apps/loone-model/) using python.