### PR TITLE
Add instructions for listing available archived-data dates in notebook

### DIFF
--- a/download-archived-data.ipynb
+++ b/download-archived-data.ipynb
@@ -13,7 +13,7 @@
    "id": "ef6b9ab3-3c4f-49cc-9d5b-1da65b8d2165",
    "metadata": {},
    "source": [
-    "This notebook shows a few different ways to download the files associated with the LOONE runs carried out by the [Loone Forecast App](https://close-habs.aquaveo.com/apps/loone-model/)"
+    "This notebook shows how to use python to download the files associated with the LOONE runs carried out by the [Loone Forecast App](https://close-habs.aquaveo.com/apps/loone-model/)"
    ]
   },
   {
@@ -68,7 +68,7 @@
    "id": "0627b941-bc92-4291-bb53-dd534ea6ff42",
    "metadata": {},
    "source": [
-    "#### 2. Import Packages and set Configuration Variables"
+    "#### 2. Import Packages"
    ]
   },
   {
@@ -85,23 +85,57 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7cd0b1f8-53ba-4f1a-92cb-03b9db818ee7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Configuration\n",
-    "date = datetime(2026, 3, 10)                                # The date of the run whose data you want\n",
-    "output_path = os.path.join(os.getcwd(), 'archived-data')    # The directory where you want the downloaded files to go"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "63adbec2-7724-4546-afdf-e5c1a016351f",
    "metadata": {},
    "source": [
-    "#### 3. Helper Function"
+    "#### 3. Helper Functions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "101fce88",
+   "metadata": {},
+   "source": [
+    "The following function can be used to list which dates have data available:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f2ad49b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def print_dates_with_archived_data():\n",
+    "    \"\"\"Print the dates for which archived data is available.\"\"\"\n",
+    "    # Get client and bucket for downloading the data\n",
+    "    bucket_name = 'loone-forecast-datastore'\n",
+    "    prefix = f'public'\n",
+    "    client = storage.Client.create_anonymous_client()\n",
+    "    \n",
+    "    # List blobs in the bucket with the specified prefix\n",
+    "    blobs = client.list_blobs(bucket_name, prefix=prefix)\n",
+    "    \n",
+    "    # Extract unique dates from the blob names\n",
+    "    dates = set()\n",
+    "    \n",
+    "    for blob in blobs:\n",
+    "        # Extract the date from the blob name\n",
+    "        date = blob.name.split('/')[1]\n",
+    "\n",
+    "        try:\n",
+    "            # Check that the current item is a date prefix\n",
+    "            if datetime.strptime(date, '%Y-%m-%d'):\n",
+    "                # Current item is a date prefix, add it to the set of dates\n",
+    "                dates.add(date)\n",
+    "        except ValueError:\n",
+    "            # Current item is not a date prefix, skip it\n",
+    "            continue\n",
+    "    \n",
+    "    # Print the sorted list of unique dates\n",
+    "    for date in sorted(dates):\n",
+    "        print(date)"
    ]
   },
   {
@@ -119,7 +153,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def download_archived_data(date: datetime.datetime, output_path: str):\n",
+    "def download_archived_data(date, output_path: str):\n",
     "    \"\"\"Downloads the archived data for the specified date to the given output location.\n",
     "\n",
     "    Args:\n",
@@ -168,7 +202,33 @@
    "id": "005ef4db-2c12-4ddb-af5e-18f54fde1f0c",
    "metadata": {},
    "source": [
-    "#### 4. Run the Function"
+    "#### 4. Run the Functions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ed57c8c",
+   "metadata": {},
+   "source": [
+    "##### Print the dates that have data available:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "016bc906",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_dates_with_archived_data()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b74537cb",
+   "metadata": {},
+   "source": [
+    "##### Download Data for a Specified Date:"
    ]
   },
   {
@@ -178,13 +238,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Configuration\n",
+    "date = datetime(2026, 4, 10)                                # The date of the run whose data you want\n",
+    "output_path = os.path.join(os.getcwd(), 'archived-data')    # The directory where you want the downloaded files to go\n",
+    "\n",
+    "# Download the archived data for the specified date to the given output location\n",
     "download_archived_data(date, output_path)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "tethys",
    "language": "python",
    "name": "python3"
   },
@@ -198,7 +263,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.3"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Add a notebook section showing how to list dates with available archived data
- Move configuration variables into the same cell as download_archived_data() to simplify reruns
- Remove the datetime type hint for better Python version compatibility
- Update notebook wording for accuracy